### PR TITLE
correct test with recent compatibility changes and exclude SeaQuest

### DIFF
--- a/gymnax/registration.py
+++ b/gymnax/registration.py
@@ -108,7 +108,7 @@ registered_envs = [
     "Asterix-MinAtar",
     "Breakout-MinAtar",
     "Freeway-MinAtar",
-    # "Seaquest-MinAtar",
+    "Seaquest-MinAtar",
     "SpaceInvaders-MinAtar",
     "Catch-bsuite",
     "DeepSea-bsuite",

--- a/gymnax/utils/test_helpers.py
+++ b/gymnax/utils/test_helpers.py
@@ -4,9 +4,7 @@ import numpy as np
 from .state_translate import np_state_to_jax
 
 
-def assert_correct_state(
-    env_gym, env_name: str, state_jax: dict, atol: float = 1e-4
-):
+def assert_correct_state(env_gym, env_name: str, state_jax: dict, atol: float = 1e-4):
     """Check that numpy-based env state is same as JAX dict."""
     state_gym = np_state_to_jax(env_gym, env_name)
     # print(state_gym)
@@ -16,10 +14,9 @@ def assert_correct_state(
         # print(k, jax_value, state_gym[k])
         if k not in ["time", "terminal"]:
             if type(jax_value) in [
-                jax.interpreters.xla._DeviceArray,
-                jaxlib.xla_extension.Buffer,
-                jaxlib.xla_extension.ArrayImpl,
+                jax.Array,
                 np.ndarray,
+                jaxlib.xla_extension.ArrayImpl,
             ]:
                 assert np.allclose(jax_value, state_gym[k], atol=atol)
             else:
@@ -28,10 +25,9 @@ def assert_correct_state(
                 if type(state_gym[k]) in [
                     float,
                     np.float64,
-                    jax.interpreters.xla._DeviceArray,
-                    jaxlib.xla_extension.Buffer,
-                    np.ndarray,
+                    jax.Array,
                     jaxlib.xla_extension.ArrayImpl,
+                    np.ndarray,
                 ]:
                     np.allclose(state_gym[k], jax_value, atol=atol)
                 else:
@@ -52,7 +48,7 @@ def assert_correct_transit(
     if not done_gym:
         assert np.allclose(obs_gym, obs_jax, atol=atol)
     assert np.allclose(reward_gym, reward_jax, atol=atol)
-    assert np.alltrue(done_gym == done_jax)
+    assert np.all(done_gym == done_jax)
 
 
 def minatar_action_map(action_jax: int, env_name: str):

--- a/tests/minatar/test_seaquest.py
+++ b/tests/minatar/test_seaquest.py
@@ -27,6 +27,7 @@ from seaquest_helpers import (
     step_timers_numpy,
     surface_numpy,
 )
+import pytest
 
 num_episodes, num_steps, tolerance = 5, 10, 1e-04
 env_name_gym, env_name_jax = "seaquest", "Seaquest-MinAtar"
@@ -36,65 +37,68 @@ def test_sub_steps():
     """Test a step transition for the env."""
     rng = jax.random.PRNGKey(0)
     env_gym = Environment(env_name_gym, sticky_action_prob=0.0)
-    env_jax, env_params = gymnax.make(env_name_jax)
+    with pytest.raises(NotImplementedError):
+        env_jax, env_params = gymnax.make(env_name_jax)
 
-    # Loop over test episodes
-    for ep in range(num_episodes):
-        obs = env_gym.reset()
-        # Loop over test episode steps
-        for s in range(num_steps):
-            rng, key_step, key_action = jax.random.split(rng, 3)
-            state = np_state_to_jax(env_gym, env_name_jax)
-            action = env_jax.action_space(env_params).sample(key_action)
-            action_gym = minatar_action_map(action, env_name_jax)
+    # # Loop over test episodes
+    # for ep in range(num_episodes):
+    #     obs = env_gym.reset()
+    #     # Loop over test episode steps
+    #     for s in range(num_steps):
+    #         rng, key_step, key_action = jax.random.split(rng, 3)
+    #         state = np_state_to_jax(env_gym, env_name_jax)
+    #         action = env_jax.action_space(env_params).sample(key_action)
+    #         action_gym = minatar_action_map(action, env_name_jax)
 
-            step_agent_numpy(env_gym, action_gym)
-            state_jax_a = step_agent(state, action_gym, env_params)
-            assert_correct_state(env_gym, env_name_jax, state_jax_a, tolerance)
+    #         step_agent_numpy(env_gym, action_gym)
+    #         state_jax_a = step_agent(state, action_gym, env_params)
+    #         assert_correct_state(env_gym, env_name_jax, state_jax_a, tolerance)
 
-            reward = step_bullets_numpy(env_gym)
-            state_jax_b = step_bullets(state_jax_a)
-            assert_correct_state(env_gym, env_name_jax, state_jax_a, tolerance)
+    #         reward = step_bullets_numpy(env_gym)
+    #         state_jax_b = step_bullets(state_jax_a)
+    #         assert_correct_state(env_gym, env_name_jax, state_jax_a, tolerance)
 
-            if env_gym.env.terminal:
-                break
+    #         if env_gym.env.terminal:
+    #             break
 
 
 def test_reset():
     """Test reset obs/state is in space of NumPy version."""
     # env_gym = Environment(env_name_gym, sticky_action_prob=0.0)
     rng = jax.random.PRNGKey(0)
-    env_jax, env_params = gymnax.make(env_name_jax)
-    for ep in range(num_episodes):
-        rng, rng_input = jax.random.split(rng)
-        obs, state = env_jax.reset(rng_input, env_params)
-        # Check state and observation space
-        env_jax.state_space(env_params).contains(state)
-        env_jax.observation_space(env_params).contains(obs)
+    with pytest.raises(NotImplementedError):
+        env_jax, env_params = gymnax.make(env_name_jax)
+    # for ep in range(num_episodes):
+    #     rng, rng_input = jax.random.split(rng)
+    #     obs, state = env_jax.reset(rng_input, env_params)
+    #     # Check state and observation space
+    #     env_jax.state_space(env_params).contains(state)
+    #     env_jax.observation_space(env_params).contains(obs)
 
 
 def test_get_obs():
     """Test observation function."""
     rng = jax.random.PRNGKey(0)
     env_gym = Environment(env_name_gym, sticky_action_prob=0.0)
-    env_jax, env_params = gymnax.make(env_name_jax)
+    with pytest.raises(NotImplementedError):
+        env_jax, env_params = gymnax.make(env_name_jax)
 
-    # Loop over test episodes
-    for ep in range(num_episodes):
-        env_gym.reset()
-        # Loop over test episode steps
-        for s in range(num_steps):
-            rng, key_step, key_action = jax.random.split(rng, 3)
-            action = env_jax.action_space.sample(key_action)
-            action_gym = minatar_action_map(action, env_name_jax)
-            # Step gym environment get state and trafo in jax dict
-            reward_gym = env_gym.act(action_gym)
-            obs_gym = env_gym.state()
-            state = np_state_to_jax(env_gym, env_name_jax)
-            obs_jax = env_jax.get_obs(state, env_params)
-            # Check for correctness of observations
-            assert (obs_gym == obs_jax).all()
-            done_gym = env_gym.env.terminal
-            # Start a new episode if the previous one has terminated
-            if done_gym:
-                break
+    # # Loop over test episodes
+    # for ep in range(num_episodes):
+    #     env_gym.reset()
+    #     # Loop over test episode steps
+    #     for s in range(num_steps):
+    #         rng, key_step, key_action = jax.random.split(rng, 3)
+    #         action = env_jax.action_space.sample(key_action)
+    #         action_gym = minatar_action_map(action, env_name_jax)
+    #         # Step gym environment get state and trafo in jax dict
+    #         reward_gym = env_gym.act(action_gym)
+    #         obs_gym = env_gym.state()
+    #         state = np_state_to_jax(env_gym, env_name_jax)
+    #         obs_jax = env_jax.get_obs(state, env_params)
+    #         # Check for correctness of observations
+    #         assert (obs_gym == obs_jax).all()
+    #         done_gym = env_gym.env.terminal
+    #         # Start a new episode if the previous one has terminated
+    #         if done_gym:
+    #             break

--- a/tests/wrappers/test_dm_env.py
+++ b/tests/wrappers/test_dm_env.py
@@ -15,9 +15,9 @@ def test_dmenv_wrapper():
 
     reset_fn = jax.vmap(wrapped_env.reset, in_axes=(0,))
     timesteps = reset_fn(keys)
-    chex.assert_tree_all_equal_shapes(o, timesteps.observation)
-    chex.assert_tree_all_equal_shapes(r, timesteps.reward)
-    chex.assert_tree_all_equal_shapes(d, timesteps.discount)
+    chex.assert_trees_all_equal_shapes(o, timesteps.observation)
+    chex.assert_trees_all_equal_shapes(r, timesteps.reward)
+    chex.assert_trees_all_equal_shapes(d, timesteps.discount)
 
     step_fn = jax.vmap(wrapped_env.step, in_axes=(0, 0, 0))
     new_timesteps = step_fn(keys, timesteps, action)


### PR DESCRIPTION
- Correct tests to match the recent Jax changes (unification of multiple types of Array into jax.Array).
- Make sure that SeaQuests fail and catch it properly while it is unsupported. 